### PR TITLE
Return proper error for error HTTP response

### DIFF
--- a/yelpapi/yelpapi.py
+++ b/yelpapi/yelpapi.py
@@ -290,6 +290,7 @@ class YelpAPI:
             params=parameters,
             timeout=self._timeout_s,
         )
+        response.raise_for_status() # will raise error if not error status code received: https://requests.readthedocs.io/en/latest/api/#requests.Response.raise_for_status
         response_json = response.json()  # shouldn't happen, but this will raise a ValueError if the response isn't JSON
 
         # Yelp can return one of many different API errors, so check for one of them.


### PR DESCRIPTION
Hi, 
I believe that this package should throw proper error when error HTTP status is returned from API. This will improve ability to distinguish and manage issues on the developer end.